### PR TITLE
Feature/rpr 19 research and test dropwizard test package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ build/
 
 # Mac OS X
 .DS_Store
+
+out/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RestPR
- 
+
 
 RestPR is a RESTful web api that enables competitive communities to create player leaderboard seasons using tournament match data from services like Challonge.com
 
@@ -28,7 +28,7 @@ These divisions can be used by tournament officials to incentivise competition.
 Additionally divisions within a leaderboard can be used to produce round robin side events or general seeding.
 
 At the end of the season it can be marked as finished and a subjective power rankings can be submitted.
-Users can see how many days left 
+Users can see how many days left
 
 Panelists involved in the subjective power rankings can utilize the upset filtering to support their decisions.
 
@@ -74,7 +74,7 @@ The following examples can be excuted with netcat using heredocs like this:
 
 #GET
 Get Users and partial match user_login and display_name query parameters
-
+```
 	GET /user?user_login=LOGIN&display_name=DISPLAY HTTP/1.0
 
 	HTTP/1.1 200 OK
@@ -83,9 +83,9 @@ Get Users and partial match user_login and display_name query parameters
 	Content-Length: 241
 
 	[{"user_id":16,"user_login":"16 SER LOGIN","display_name":"16 DISPLAY NAME"},{"user_id":1,"user_login":"NEAT USER LOGIN","display_name":"NEAT DISPLAY NAME"},{"user_id":14,"user_login":"UNIQUE SER LOGIN","display_name":"UNIQUE DISPLAY NAME"}]%
-
+```
 Get all Users
-
+```
 	GET /user/all HTTP/1.0
 
 	HTTP/1.1 200 OK
@@ -95,9 +95,9 @@ Get all Users
 	Content-Length: 1346
 
 	[{"user_id":15,"user_login":"testnew","display_name":"brandnew"},{"user_id":1,"user_login":"NEAT USER LOGIN","display_name":"NEAT DISPLAY NAME"},{"user_id":21,"user_login":"pokjhnb","display_name":"983"},{"user_id":22,"user_login":"wed","display_name":"ffg"},{"user_id":23,"user_login":"ff","display_name":"uh"},{"user_id":25,"user_login":"fb","display_name":"ygv"},{"user_id":27,"user_login":"fgbh","display_name":"jhg"},{"user_id":29,"user_login":"fbbn","display_name":"uhb"},{"user_id":37,"user_login":"ffff","display_name":"qwer"},{"user_id":14,"user_login":"UNIQUE SER LOGIN","display_name":"UNIQUE DISPLAY NAME"},{"user_id":16,"user_login":"16 SER LOGIN","display_name":"16 DISPLAY NAME"},{"user_id":18,"user_login":"tesfffftnew","display_name":"ddfg"},{"user_id":19,"user_login":"rthj","display_name":"wdf"},{"user_id":20,"user_login":"tfgh","display_name":"lkjhg"},{"user_id":24,"user_login":"67890","display_name":"wertyu"},{"user_id":31,"user_login":"ytgv","display_name":"tf"},{"user_id":32,"user_login":"ikj","display_name":"yhj"},{"user_id":34,"user_login":"wef","display_name":"wwrwhwrh"},{"user_id":36,"user_login":"aef","display_name":"qqwwd"},{"user_id":40,"user_login":"qqazzz","display_name":"eeeee"},{"user_id":41,"user_login":"qqazsszz","display_name":"eesseee"},{"user_id":42,"user_login":"qqaz33sszz","display_name":"333"}]
-
+```
 Get User by ID
-
+```
 	GET /user/16 HTTP/1.0
 
 	HTTP/1.1 200 OK
@@ -106,9 +106,9 @@ Get User by ID
 	Content-Length: 75
 
 	{"user_id":16,"user_login":"16 SER LOGIN","display_name":"16 DISPLAY NAME"}
-
+```
 Get Seasons
-
+```
   GET /season HTTP/1.0
 
   HTTP/1.1 200 OK
@@ -118,9 +118,9 @@ Get Seasons
   Content-Length: 1450
 
   [{"season_id":6,"community_name":"GOINGO LLALALA","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":5,"community_name":"GOINGO wet","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":41,"community_name":"RAW TOPH","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":2,"community_name":"S96385kk JANK","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":3,"community_name":"S99876385kk wet","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":4,"community_name":"S998767777385kk wet","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":27,"community_name":"SS654 kk wet","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":22,"community_name":"SSBM Oregon Kermugens","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":25,"community_name":"SSBM kk Kermugens","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":23,"community_name":"SSBM rrr Kermugens","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":1,"community_name":"dankmemers","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200}]%
-
+```
 Get all Seasons
-
+```
   GET /season/all HTTP/1.0
 
   HTTP/1.1 200 OK
@@ -130,9 +130,9 @@ Get all Seasons
   Content-Length: 1450
 
   [{"season_id":22,"community_name":"SSBM Oregon Kermugens","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":23,"community_name":"SSBM rrr Kermugens","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":1,"community_name":"dankmemers","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":25,"community_name":"SSBM kk Kermugens","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":27,"community_name":"SS654 kk wet","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":2,"community_name":"S96385kk JANK","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":3,"community_name":"S99876385kk wet","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":4,"community_name":"S998767777385kk wet","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":5,"community_name":"GOINGO wet","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":6,"community_name":"GOINGO LLALALA","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200},{"season_id":41,"community_name":"RAW TOPH","cycle_format":"Jan","cycle_count":"Monthly","elo_default_seed":1200,"year":1200}]%
-
+```
 Get Season by ID
-
+```
   GET /season/61 HTTP/1.0
 
   HTTP/1.1 200 OK
@@ -141,10 +141,10 @@ Get Season by ID
   Content-Length: 126
 
   {"season_id":61,"community_name":"Test POST","cycle_format":"Feb","cycle_count":"Monthly","elo_default_seed":1200,"year":1200}%
-
+```
 #POST
 Post user
-
+```
 	POST /user/ HTTP/1.0
 	Content-Type: application/json
 	Content-Length:56
@@ -158,9 +158,9 @@ Post user
   Date: Thu, 13 Aug 2015 21:52:51 GMT
   Location: http://127.0.0.1:8008/56
   Content-Length: 0
-
+```
 Post Season
-
+```
   POST /season/ HTTP/1.0
   Content-Length:163
   Content-Type: application/json
@@ -178,10 +178,10 @@ Post Season
   Date: Thu, 13 Aug 2015 21:48:16 GMT
   Location: http://127.0.0.1:8008/61
   Content-Length: 0
-
+```
 #PUT
 Update user by id
-
+```
 	PUT /user/52 HTTP/1.0
 	Content-Type: application/json
 	Content-Length:56
@@ -190,9 +190,9 @@ Update user by id
 	  "display_name": "TEST44",
 	  "user_login": "TESTAA"
 	}
-
+```
 Update season by id
-
+```
   PUT /season/61 HTTP/1.0
   Content-Type: application/json
   Content-Length:126
@@ -202,19 +202,21 @@ Update season by id
   HTTP/1.1 200 OK
   Date: Thu, 13 Aug 2015 22:07:25 GMT
   Content-Length: 0
-
+```
 #DELETE
-
+```
 Delete user by id
 	DELETE /user/32 HTTP/1.0
 
 	HTTP/1.1 200 OK
 	Date: Sat, 08 Aug 2015 19:04:59 GMT
 	Content-Length: 0
-
+```
+```
 Delete season by id
   DELETE /season/61 HTTP/1.0
 
   HTTP/1.1 200 OK
   Date: Thu, 13 Aug 2015 22:10:01 GMT
   Content-Length: 0
+```

--- a/README.md
+++ b/README.md
@@ -204,16 +204,16 @@ Update season by id
   Content-Length: 0
 ```
 #DELETE
-```
 Delete user by id
+```
 	DELETE /user/32 HTTP/1.0
 
 	HTTP/1.1 200 OK
 	Date: Sat, 08 Aug 2015 19:04:59 GMT
 	Content-Length: 0
 ```
-```
 Delete season by id
+```
   DELETE /season/61 HTTP/1.0
 
   HTTP/1.1 200 OK

--- a/TODO_Integration_Testing_Notes
+++ b/TODO_Integration_Testing_Notes
@@ -1,0 +1,25 @@
+    //TODO move onto integration once this API has interaction (integration) accross resources (units) that are already tested
+    //NOTE: Integration testing dependancies on the current prototype of the API
+    //USER resource is independant
+    //User permissions depends on users and seasons
+    //Season is independant
+    //Tournament depends on season due to eventOf foriegn key
+
+    //The main interaction flow of RestPR:
+      //Create user, create season, post tournaments
+         //Posted tournaments kick off a logic heavy process of hitting the challonge site
+            //Adding new players, adding new matches and then processing the elo's of all the players within the season
+
+    //Season authorized User posts new tournament
+    //Tournament row entry is created
+      //All of these new matches from the tournament need to added
+        //With each match addition players have to be looked up if they already exist and matched to
+          //If they dont exist they get made
+
+    //TODO add date to tournament record so when rankings get calculated the resultset of matches for the season can get
+    //sorted by tournament date and then within each tournament they're ordered by tournament depth
+    //Figure out sql order by to sort tournaments by depth
+        //MOST IMPORTANT THING is that matches get put in with correct tournament id, depth into tournament (WR1, LR1, GF, GFR)
+
+        //TODO design way to handle match addition job queue
+        //This really is a batch addition process done by the tournament resource.

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     compile "org.codehaus.groovy:groovy:${groovyVersion}"
     compile "io.dropwizard:dropwizard-core:${dropwizardVersion}"
     compile "io.dropwizard:dropwizard-jdbi:${dropwizardVersion}"
+    compile "io.dropwizard:dropwizard-testing:${dropwizardVersion}"
 }
 
 codenarc {

--- a/src/main/groovy/edu/oregonstate/mist/restpr/api/ErrorPOJO.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/api/ErrorPOJO.groovy
@@ -7,5 +7,16 @@ class ErrorPOJO {
   String errorMessage
   Integer errorCode
 
+  boolean equals(o) {
+    if (this.is(o)) return true
+    if (getClass() != o.class) return false
+
+    ErrorPOJO errorPOJO = (ErrorPOJO) o
+
+    if (errorCode != errorPOJO.errorCode) return false
+    if (errorMessage != errorPOJO.errorMessage) return false
+
+    return true
+  }
 
 }

--- a/src/main/groovy/edu/oregonstate/mist/restpr/api/ErrorPOJO.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/api/ErrorPOJO.groovy
@@ -7,12 +7,5 @@ class ErrorPOJO {
   String errorMessage
   Integer errorCode
 
-  public ErrorPOJO(){
-    // Jackson deserialization
-  }
 
-  public ErrorPOJO(String errorMessage, Integer errorCode){
-    this.errorMessage = errorMessage
-    this.errorCode = errorCode
-  }
 }

--- a/src/main/groovy/edu/oregonstate/mist/restpr/api/ErrorPOJO.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/api/ErrorPOJO.groovy
@@ -8,15 +8,24 @@ class ErrorPOJO {
   Integer errorCode
 
   boolean equals(o) {
-    if (this.is(o)) return true
-    if (getClass() != o.class) return false
+    if (this.is(o)){
+      return true
+    }
+    if (getClass() != o.class){
+      return false
+    }
 
     ErrorPOJO errorPOJO = (ErrorPOJO) o
 
-    if (errorCode != errorPOJO.errorCode) return false
-    if (errorMessage != errorPOJO.errorMessage) return false
+    if (errorCode != errorPOJO.errorCode) {
+      return false
+    }
+    if (errorMessage != errorPOJO.errorMessage){
+      return false
+    }
 
-    return true
+
+    true
   }
 
 }

--- a/src/main/groovy/edu/oregonstate/mist/restpr/api/Season.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/api/Season.groovy
@@ -12,19 +12,34 @@ class Season {
   Integer year
 
   boolean equals(o) {
-    if (this.is(o)) return true
-    if (getClass() != o.class) return false
-
+    if (this.is(o)){
+      return true
+    }
+    if (getClass() != o.class) {
+      return false
+    }
     Season season = (Season) o
 
-    if (community_name != season.community_name) return false
-    if (cycle_count != season.cycle_count) return false
-    if (cycle_format != season.cycle_format) return false
-    if (elo_default_seed != season.elo_default_seed) return false
-    if (season_id != season.season_id) return false
-    if (year != season.year) return false
+    if (community_name != season.community_name) {
+      return false
+    }
+    if (cycle_count != season.cycle_count) {
+      return false
+    }
+    if (cycle_format != season.cycle_format){
+      return false
+    }
+    if (elo_default_seed != season.elo_default_seed){
+      return false
+    }
+    if (season_id != season.season_id){
+      return false
+    }
+    if (year != season.year){
+      return false
+    }
 
-    return true
+    true
   }
 }
 

--- a/src/main/groovy/edu/oregonstate/mist/restpr/api/Season.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/api/Season.groovy
@@ -10,5 +10,21 @@ class Season {
   String  cycle_count
   Integer elo_default_seed
   Integer year
+
+  boolean equals(o) {
+    if (this.is(o)) return true
+    if (getClass() != o.class) return false
+
+    Season season = (Season) o
+
+    if (community_name != season.community_name) return false
+    if (cycle_count != season.cycle_count) return false
+    if (cycle_format != season.cycle_format) return false
+    if (elo_default_seed != season.elo_default_seed) return false
+    if (season_id != season.season_id) return false
+    if (year != season.year) return false
+
+    return true
+  }
 }
 

--- a/src/main/groovy/edu/oregonstate/mist/restpr/api/User.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/api/User.groovy
@@ -10,15 +10,25 @@ class User{
   String display_name
 
   boolean equals(o) {
-    if (this.is(o)) return true
-    if (getClass() != o.class) return false
+    if (this.is(o)){
+      return true
+    }
+    if (getClass() != o.class){
+      return false
+    }
 
     User user = (User) o
 
-    if (display_name != user.display_name) return false
-    if (user_id != user.user_id) return false
-    if (user_login != user.user_login) return false
+    if (display_name != user.display_name){
+      return false
+    }
+    if (user_id != user.user_id){
+      return false
+    }
+    if (user_login != user.user_login){
+      return false
+    }
 
-    return true
+    true
   }
 }

--- a/src/main/groovy/edu/oregonstate/mist/restpr/api/User.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/api/User.groovy
@@ -8,4 +8,17 @@ class User{
   Integer user_id
   String user_login
   String display_name
+
+  boolean equals(o) {
+    if (this.is(o)) return true
+    if (getClass() != o.class) return false
+
+    User user = (User) o
+
+    if (display_name != user.display_name) return false
+    if (user_id != user.user_id) return false
+    if (user_login != user.user_login) return false
+
+    return true
+  }
 }

--- a/src/main/groovy/edu/oregonstate/mist/restpr/resources/SeasonResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/resources/SeasonResource.groovy
@@ -5,7 +5,6 @@ import edu.oregonstate.mist.restpr.api.Season
 import edu.oregonstate.mist.restpr.db.SeasonDAO
 import com.google.common.base.Optional
 import javax.validation.Valid
-import javax.validation.constraints.NotNull
 import javax.ws.rs.Consumes
 import javax.ws.rs.DELETE
 import javax.ws.rs.GET

--- a/src/main/groovy/edu/oregonstate/mist/restpr/resources/SeasonResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/resources/SeasonResource.groovy
@@ -91,13 +91,12 @@ class SeasonResource {
 
       ErrorPOJO returnError
       if(constraintError.contains("SEASON_U_COMMUNITY_NAME")){//USER LOGIN IS NOT UNIQUE
-
-        returnError = new ErrorPOJO("Community name is not unique", Response.Status.CONFLICT.getStatusCode())
+        returnError = new ErrorPOJO(errorMessage: "Community name is not unique", errorCode: Response.Status.CONFLICT.getStatusCode())
 
       }else{//Some other error, should be logged
 
         System.out.println(e.localizedMessage)
-        returnError = new ErrorPOJO("Unknown error.", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
+        returnError = new ErrorPOJO(errorMessage: "Unknown error.",errorCode: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
       }
 
       return Response.status(returnError.getErrorCode()).entity(returnError).build()
@@ -138,7 +137,7 @@ class SeasonResource {
     Response returnResponse
 
     if (returnSeason == null) {
-      ErrorPOJO returnError = new ErrorPOJO("Resource not found.",Response.Status.NOT_FOUND.getStatusCode())
+      ErrorPOJO returnError = new ErrorPOJO(errorMessage:  "Resource not found.",errorCode: Response.Status.NOT_FOUND.getStatusCode())
       returnResponse = Response.status(Response.Status.NOT_FOUND).entity(returnError).build()
 
     }else{

--- a/src/main/groovy/edu/oregonstate/mist/restpr/resources/UserResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/resources/UserResource.groovy
@@ -130,7 +130,7 @@ class UserResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   //Entity Type: User
-  public Response findUserById(@PathParam("user_id") Integer user_id) { //TODO UNIT TEST THIS
+  public Response findUserById(@PathParam("user_id") Integer user_id) {
     User returnUser = userDAO.getUserById(user_id)
     Response returnResponse
     if (returnUser == null) {
@@ -156,15 +156,14 @@ class UserResource {
   @PUT
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  public Response putUserById(@PathParam("user_id") Integer user_id ,@Valid User newUser){ //TODO UNIT TEST THIS
-
-    //TODO CREATE TESTS TO TEST RESPONSE CODES
-
+  public Response putUserById(@PathParam("user_id") Integer user_id ,@Valid User newUser){ 
     Response returnResponse
 
     User checkForUser_id = userDAO.getUserById(user_id)
     if(checkForUser_id == null){
       userDAO.postUserToUserId(user_id, newUser.getUser_login(),newUser.getDisplay_name())
+      //TODO TEST CREATED URI BEING SET CORRECTLY
+      //TODO Make sure the location header is being set to the correct URI that can be GETTED to
       URI createdURI = URI.create("/"+user_id)
       returnResponse = Response.created(createdURI).build()
     }else{
@@ -188,7 +187,7 @@ class UserResource {
   @Path("/{user_id}")
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
-  public Response deleteUserById(@PathParam("user_id") Integer user_id){ //TODO UNIT TEST THIS
+  public Response deleteUserById(@PathParam("user_id") Integer user_id){
     //TODO add authentication for this method
     userDAO.deleteUserById(user_id)
     Response returnResponse = Response.ok().build()

--- a/src/main/groovy/edu/oregonstate/mist/restpr/resources/UserResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/resources/UserResource.groovy
@@ -93,9 +93,9 @@ class UserResource {
       try {
         userDAO.postUser(newUser.getUser_login(),newUser.getDisplay_name())
         URI createdURI = URI.create("/"+userDAO.getLatestUserId())
-        //TODO TEST 201 RESPONSE CODE
         returnResponse = Response.created(createdURI).build()
-        //TODO TEST CREATED URI BEING SET CORRECTLY, MOCK GETLATESTUSERID RETURNVALUE
+        //TODO TEST CREATED URI BEING SET CORRECTLY
+        //TODO Make sure the location header is being set to the correct URI that can be GETTED to
       } catch (UnableToExecuteStatementException e){
         String constraintError = e.getMessage()
 
@@ -130,7 +130,7 @@ class UserResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   //Entity Type: User
-  public Response findUserById(@PathParam("user_id") Integer user_id) {
+  public Response findUserById(@PathParam("user_id") Integer user_id) { //TODO UNIT TEST THIS
     User returnUser = userDAO.getUserById(user_id)
     Response returnResponse
     if (returnUser == null) {
@@ -156,7 +156,7 @@ class UserResource {
   @PUT
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  public Response putUserById(@PathParam("user_id") Integer user_id ,@Valid User newUser){
+  public Response putUserById(@PathParam("user_id") Integer user_id ,@Valid User newUser){ //TODO UNIT TEST THIS
 
     //TODO CREATE TESTS TO TEST RESPONSE CODES
 
@@ -188,7 +188,7 @@ class UserResource {
   @Path("/{user_id}")
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
-  public Response deleteUserById(@PathParam("user_id") Integer user_id){
+  public Response deleteUserById(@PathParam("user_id") Integer user_id){ //TODO UNIT TEST THIS
     //TODO add authentication for this method
     userDAO.deleteUserById(user_id)
     Response returnResponse = Response.ok().build()

--- a/src/main/groovy/edu/oregonstate/mist/restpr/resources/UserResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/resources/UserResource.groovy
@@ -91,13 +91,13 @@ class UserResource {
       ErrorPOJO returnError
       if(constraintError.contains("PR_USER_U_USER_LOGIN")){//USER LOGIN IS NOT UNIQUE
 
-        returnError = new ErrorPOJO("User login is not unique", Response.Status.CONFLICT.getStatusCode())
+        returnError = new ErrorPOJO(errorMessage: "User login is not unique",errorCode: Response.Status.CONFLICT.getStatusCode())
       }else if(constraintError.contains("PR_USER_U_DISPLAY_NAME")){//DISPLAY NAME IS NOT UNIQUE
 
-        returnError = new ErrorPOJO("Display name is not unique", Response.Status.CONFLICT.getStatusCode())
+        returnError = new ErrorPOJO(errorMessage: "Display name is not unique",errorCode: Response.Status.CONFLICT.getStatusCode())
 
       }else{//Some other error, should be logged
-        returnError = new ErrorPOJO("Unknown error.", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
+        returnError = new ErrorPOJO(errorMessage: "Unknown error.", errorCode: Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
       }
 
       return Response.status(returnError.getErrorCode()).entity(returnError).build()
@@ -119,7 +119,7 @@ class UserResource {
     User returnUser = userDAO.getUserById(user_id)
     Response returnResponse
     if (returnUser == null) {
-      ErrorPOJO returnError = new ErrorPOJO("Resource not found.",Response.Status.NOT_FOUND.getStatusCode())
+      ErrorPOJO returnError = new ErrorPOJO(errorMessage:  "Resource not found.",errorCode:  Response.Status.NOT_FOUND.getStatusCode())
       returnResponse = Response.status(Response.Status.NOT_FOUND).entity(returnError).build()
 
     }else{

--- a/src/main/groovy/edu/oregonstate/mist/restpr/resources/UserResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/resources/UserResource.groovy
@@ -23,6 +23,7 @@ import javax.ws.rs.QueryParam
 import javax.ws.rs.core.Context
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
+import javax.ws.rs.core.UriBuilder
 import javax.ws.rs.core.UriInfo
 
 //TODO look up VALID annotation
@@ -92,10 +93,11 @@ class UserResource {
     }else{
       try {
         userDAO.postUser(newUser.getUser_login(),newUser.getDisplay_name())
-        URI createdURI = URI.create("/"+userDAO.getLatestUserId())
+        URI createdURI = UriBuilder.fromResource(UserResource.class).path("{user_id}").build(userDAO.getLatestUserId())
+
         returnResponse = Response.created(createdURI).build()
-        //TODO TEST CREATED URI BEING SET CORRECTLY
-        //TODO Make sure the location header is being set to the correct URI that can be GETTED to
+        //FIXME NOTE https://github.com/dropwizard/dropwizard/issues/878
+        //Created uri can't be set correctly due to a Jersey bug.
       } catch (UnableToExecuteStatementException e){
         String constraintError = e.getMessage()
 
@@ -162,8 +164,8 @@ class UserResource {
     User checkForUser_id = userDAO.getUserById(user_id)
     if(checkForUser_id == null){
       userDAO.postUserToUserId(user_id, newUser.getUser_login(),newUser.getDisplay_name())
-      //TODO TEST CREATED URI BEING SET CORRECTLY
-      //TODO Make sure the location header is being set to the correct URI that can be GETTED to
+      //FIXME NOTE https://github.com/dropwizard/dropwizard/issues/878
+      //Created uri can't be set correctly due to a Jersey bug.
       URI createdURI = URI.create("/"+user_id)
       returnResponse = Response.created(createdURI).build()
     }else{

--- a/src/main/groovy/edu/oregonstate/mist/restpr/resources/UserResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/resources/UserResource.groovy
@@ -82,7 +82,7 @@ class UserResource {
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  //Entity Type: URI
+  //Entity Type: URI or ErrorPOJO
   public Response postUser(@Valid User newUser) {
     Response returnResponse
     if(newUser.getUser_login() == newUser.getDisplay_name()){

--- a/src/main/groovy/edu/oregonstate/mist/restpr/resources/UserResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/restpr/resources/UserResource.groovy
@@ -23,6 +23,9 @@ import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 import javax.ws.rs.core.UriInfo
 
+//TODO look up VALID annotation
+//TODO look up NotNull annoation
+
 @Path("/user")
 @Produces(MediaType.APPLICATION_JSON)
 class UserResource {

--- a/src/test/groovy/edu/oregonstate/mist/restpr/api/ErrorPojoTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/api/ErrorPojoTest.groovy
@@ -25,4 +25,6 @@ class ErrorPojoTest {
 
     assertEquals(expected, actual)
   }
+
+  //TODO ADD DESERIALIZATION TEST
 }

--- a/src/test/groovy/edu/oregonstate/mist/restpr/api/ErrorPojoTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/api/ErrorPojoTest.groovy
@@ -1,0 +1,28 @@
+package edu.oregonstate.mist.restpr.api
+
+import static io.dropwizard.testing.FixtureHelpers.fixture
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.dropwizard.jackson.Jackson
+import org.junit.Test
+import static org.junit.Assert.assertEquals
+
+/**
+ * Created by georgecrary on 8/17/15.
+ */
+class ErrorPojoTest {
+  ObjectMapper MAPPER = Jackson.newObjectMapper()
+
+  @Test
+  void serializeToJSON() throws Exception {
+    ErrorPOJO error = new ErrorPOJO(
+            errorMessage: "Resource not found",
+            errorCode: 404
+    )
+    String actual = MAPPER.writeValueAsString(error)
+
+    String expected = MAPPER.writeValueAsString(
+            MAPPER.readValue(fixture("fixtures/errorpojo.json"), ErrorPOJO.class))
+
+    assertEquals(expected, actual)
+  }
+}

--- a/src/test/groovy/edu/oregonstate/mist/restpr/api/ErrorPojoTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/api/ErrorPojoTest.groovy
@@ -26,5 +26,16 @@ class ErrorPojoTest {
     assertEquals(expected, actual)
   }
 
-  //TODO ADD DESERIALIZATION TEST
+  @Test
+  void deserializeFromJSON() throws Exception{
+    ErrorPOJO expected = new ErrorPOJO(
+            errorMessage: "Resource not found",
+            errorCode: 404
+    )
+
+    ErrorPOJO actual = MAPPER.readValue(fixture("fixtures/errorpojo.json"),ErrorPOJO.class)
+
+    assertEquals(expected, actual)
+  }
+
 }

--- a/src/test/groovy/edu/oregonstate/mist/restpr/api/SeasonTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/api/SeasonTest.groovy
@@ -1,0 +1,51 @@
+package edu.oregonstate.mist.restpr.api
+
+import static io.dropwizard.testing.FixtureHelpers.fixture
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.dropwizard.jackson.Jackson
+import org.junit.Test
+import static org.junit.Assert.assertEquals
+
+/**
+ * Created by georgecrary on 8/17/15.
+ */
+class SeasonTest {
+
+  ObjectMapper MAPPER = Jackson.newObjectMapper()
+
+  @Test
+  void serializesToJSON() throws Exception{
+    Season season = new Season(  season_id:22,
+                                 community_name : "Test POST",
+                                 cycle_format :  "Feb",
+                                 cycle_count : "Monthly",
+                                 elo_default_seed: 1200,
+                                 year: 2015
+                               )
+
+    String actual = MAPPER.writeValueAsString(season)
+
+    String expected = MAPPER.writeValueAsString(
+            MAPPER.readValue(fixture("fixtures/season.json"), season.class))
+
+
+
+    assertEquals(expected, actual)
+
+  }
+
+  @Test
+  void deserializeFromJSON() throws Exception{
+    Season expected = new Season(  season_id:22,
+            community_name : "Test POST",
+            cycle_format :  "Feb",
+            cycle_count : "Monthly",
+            elo_default_seed: 1200,
+            year: 2015
+    )
+
+    Season actual = MAPPER.readValue(fixture("fixtures/season.json"),Season.class)
+
+    assertEquals(expected, actual)
+  }
+}

--- a/src/test/groovy/edu/oregonstate/mist/restpr/api/SeasonTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/api/SeasonTest.groovy
@@ -26,7 +26,7 @@ class SeasonTest {
     String actual = MAPPER.writeValueAsString(season)
 
     String expected = MAPPER.writeValueAsString(
-            MAPPER.readValue(fixture("fixtures/season.json"), season.class))
+            MAPPER.readValue(fixture("fixtures/season.json"), Season.class))
 
 
 

--- a/src/test/groovy/edu/oregonstate/mist/restpr/api/UserTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/api/UserTest.groovy
@@ -1,0 +1,37 @@
+package edu.oregonstate.mist.restpr.api
+
+import static io.dropwizard.testing.FixtureHelpers.fixture
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.dropwizard.jackson.Jackson
+import org.junit.Test
+import static org.junit.Assert.assertEquals
+
+/**
+ * Created by georgecrary on 8/17/15.
+ */
+class UserTest{
+
+  ObjectMapper MAPPER = Jackson.newObjectMapper()
+
+  @Test
+  void serializesToJSON() throws Exception{
+    User user = new User(user_id: 1, display_name: "DISPLAY_NAME_TEST" ,user_login: "USER_LOGIN_TEST")
+    String expected = MAPPER.writeValueAsString(
+            MAPPER.readValue(fixture("fixtures/user.json"), User.class))
+
+    String actual = MAPPER.writeValueAsString(user)
+
+    assertEquals(expected, actual)
+
+  }
+
+  @Test
+  void deserializesFromJSON() throws Exception{
+    User expected = new User(user_id: 1, display_name: "DISPLAY_NAME_TEST" ,user_login: "USER_LOGIN_TEST")
+    User actual = MAPPER.readValue(fixture("fixtures/user.json"), User.class)
+
+    assertEquals(expected,actual)
+
+
+  }
+}

--- a/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest
@@ -1,9 +1,15 @@
+import edu.oregonstate.mist.restpr.RESTPRApplication
+import edu.oregonstate.mist.restpr.RESTPRConfiguration
 import edu.oregonstate.mist.restpr.api.User
 import edu.oregonstate.mist.restpr.db.UserDAO
 import edu.oregonstate.mist.restpr.resources.UserResource
+import io.dropwizard.jackson.Jackson
+import io.dropwizard.testing.ResourceHelpers
 import io.dropwizard.testing.junit.ResourceTestRule
 
 import org.junit.After
+import io.dropwizard.testing.junit.DropwizardAppRule
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.AfterClass
 import org.junit.Before
 import org.junit.BeforeClass
@@ -11,16 +17,21 @@ import org.junit.ClassRule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.runners.MockitoJUnitRunner
+
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*
 
-@RunWith(MockitoJUnitRunner.class)
 class UserResourceTest{
   UserDAO dao = mock(UserDAO.class)
 
+
+
   @ClassRule
   ResourceTestRule resources = ResourceTestRule.builder()
-            .addResource(new UserResource(dao))
-            .build()
+          .addResource(new UserResource(dao))
+          .build()
 
   User user = new User(user_id: 1,  display_name: "DISPLAY_NAME_TEST", user_login: "USER_LOGIN_TEST")
 
@@ -29,6 +40,7 @@ class UserResourceTest{
   @BeforeClass
   public static void setUpClass() throws Exception {
     // Code executed before the first test method
+
   }
 
   @Before
@@ -52,14 +64,22 @@ class UserResourceTest{
 
     //DAO behavior we need to mock
     //List<User> allRESTPRUsers()
-
-
-
     // Code that tests one thing
     //Mock the DAO to test the resource's usage of the mocked DAO
+    List<User> returnMockList = new ArrayList<User>()
+    returnMockList.push(user)
+    returnMockList.push(new User(user_id: 2,  display_name: "DISPLAY_NAME_2", user_login: "USER_LOGIN_2"))
 
+    when(dao.allRESTPRUsers()).thenReturn(returnMockList)
 
-    userDAO.allRESTPRUsers()
+    Response response = resources.client().target("/user/all")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .get()
+
+    //assertThat(response.getStatusInfo()).isEqualTo(Response.Status.OK)
+    assertThat(response.getStatusInfo()).isNotEqualTo(Response.Status.OK)
+    assertThat(response.hasEntity()).isTrue()
+
 
   }
 

--- a/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest
@@ -1,0 +1,66 @@
+import edu.oregonstate.mist.restpr.api.User
+import edu.oregonstate.mist.restpr.db.UserDAO
+import edu.oregonstate.mist.restpr.resources.UserResource
+import io.dropwizard.testing.junit.ResourceTestRule
+
+import org.junit.After
+import org.junit.AfterClass
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.runners.MockitoJUnitRunner
+import static org.mockito.Mockito.*
+
+@RunWith(MockitoJUnitRunner.class)
+class UserResourceTest{
+  UserDAO dao = mock(UserDAO.class)
+
+  @ClassRule
+  ResourceTestRule resources = ResourceTestRule.builder()
+            .addResource(new UserResource(dao))
+            .build()
+
+  User user = new User(user_id: 1,  display_name: "DISPLAY_NAME_TEST", user_login: "USER_LOGIN_TEST")
+
+
+  //TODO ASSERT THAT POST FAILS ON USER_LOGIN AND DISPLAY_NAME BEING THE SAME
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    // Code executed before the first test method
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    // Code executed before each test
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    // Code executed after each test
+    reset(dao)
+  }
+
+  @Test
+  public void testGetAll_200() {
+    //TODO make database model
+
+    //Using mocking we isolate the behavior of the database by mocking the dao class
+    //We can feed the mock the behavior (db responses) we want.
+    //Using this isolation we can unit test the resource code and the responses we get back
+
+    //DAO behavior we need to mock
+    //List<User> allRESTPRUsers()
+
+
+
+    // Code that tests one thing
+    //Mock the DAO to test the resource's usage of the mocked DAO
+
+
+    userDAO.allRESTPRUsers()
+
+  }
+
+}

--- a/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
@@ -20,16 +20,16 @@ import org.mockito.runners.MockitoJUnitRunner
 
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat
 import static org.mockito.Mockito.*
 
 class UserResourceTest{
-  UserDAO dao = mock(UserDAO.class)
+  static UserDAO dao = mock(UserDAO.class)
 
 
 
   @ClassRule
-  ResourceTestRule resources = ResourceTestRule.builder()
+  public static ResourceTestRule resources = ResourceTestRule.builder()
           .addResource(new UserResource(dao))
           .build()
 
@@ -76,8 +76,7 @@ class UserResourceTest{
             .request(MediaType.APPLICATION_JSON_TYPE)
             .get()
 
-    //assertThat(response.getStatusInfo()).isEqualTo(Response.Status.OK)
-    assertThat(response.getStatusInfo()).isNotEqualTo(Response.Status.OK)
+    assertThat(response.getStatusInfo()).isEqualTo(Response.Status.OK)
     assertThat(response.hasEntity()).isTrue()
 
 

--- a/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
@@ -160,6 +160,20 @@ class UserResourceTest{
 
   }
 
+  @Test
+  public void testPost_201(){
+    when(dao.getLatestUserId()).thenReturn(1)
+
+    Response response = resources.client().target("/user/")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .post(Entity.entity(user,MediaType.APPLICATION_JSON_TYPE))
+
+    assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CREATED)
+    System.out.println(response.getHeaders())
+    System.out.println(response.getHeaderString("Location"))
+    //assertThat(response.getHeaderString("Location")).isEqualTo("/user/"+user.getUser_id())
+
+  }
 
 
 

--- a/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
@@ -104,7 +104,7 @@ class UserResourceTest{
       ErrorPOJO expected = new ErrorPOJO(errorMessage:  "user_login and display_name fields are not unique.", errorCode: Response.Status.CONFLICT.getStatusCode())
 
       assertEquals(expected, actual)
-    }catch (com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException e ){
+    }catch (UnrecognizedPropertyException e ){
       //extends com.fasterxml.jackson.databind.JsonMappingException
       fail("Mapping to ErrorPOJO failed. Received unexpected Response Entity JSON Schema")
     }

--- a/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
@@ -1,5 +1,6 @@
-import edu.oregonstate.mist.restpr.RESTPRApplication
-import edu.oregonstate.mist.restpr.RESTPRConfiguration
+package edu.oregonstate.mist.restpr.resources
+
+import edu.oregonstate.mist.restpr.api.ErrorPOJO
 import edu.oregonstate.mist.restpr.api.User
 import edu.oregonstate.mist.restpr.db.UserDAO
 import edu.oregonstate.mist.restpr.resources.UserResource
@@ -17,22 +18,25 @@ import org.junit.ClassRule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.runners.MockitoJUnitRunner
+import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException
 
+import javax.ws.rs.client.Entity
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
+
+import static io.dropwizard.testing.FixtureHelpers.fixture
 import static org.assertj.core.api.Assertions.assertThat
 import static org.mockito.Mockito.*
 
 class UserResourceTest{
   static UserDAO dao = mock(UserDAO.class)
-
-
-
+  ObjectMapper MAPPER = Jackson.newObjectMapper()
   @ClassRule
   public static ResourceTestRule resources = ResourceTestRule.builder()
           .addResource(new UserResource(dao))
           .build()
 
+  List<User> returnMockList
   User user = new User(user_id: 1,  display_name: "DISPLAY_NAME_TEST", user_login: "USER_LOGIN_TEST")
 
 
@@ -46,6 +50,8 @@ class UserResourceTest{
   @Before
   public void setUp() throws Exception {
     // Code executed before each test
+    returnMockList = new ArrayList<User>()
+    returnMockList.push(user)
   }
 
   @After
@@ -64,12 +70,7 @@ class UserResourceTest{
 
     //DAO behavior we need to mock
     //List<User> allRESTPRUsers()
-    // Code that tests one thing
     //Mock the DAO to test the resource's usage of the mocked DAO
-    List<User> returnMockList = new ArrayList<User>()
-    returnMockList.push(user)
-    returnMockList.push(new User(user_id: 2,  display_name: "DISPLAY_NAME_2", user_login: "USER_LOGIN_2"))
-
     when(dao.allRESTPRUsers()).thenReturn(returnMockList)
 
     Response response = resources.client().target("/user/all")
@@ -78,8 +79,79 @@ class UserResourceTest{
 
     assertThat(response.getStatusInfo()).isEqualTo(Response.Status.OK)
     assertThat(response.hasEntity()).isTrue()
-
-
   }
+
+  @Test
+  public void testGetMatch_200(){
+    when(dao.getPRUSERSmatch(anyString(),anyString())).thenReturn(returnMockList)
+
+    Response response = resources.client().target("/user/")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .get()
+
+    assertThat(response.getStatusInfo()).isEqualTo(Response.Status.OK)
+    assertThat(response.hasEntity()).isTrue()
+  }
+
+  @Test
+  public void testPost_409_Duplicate_Fields(){
+    User duplicate_fields = new User(user_id: 1, user_login: "dupe", display_name: "dupe")
+
+    Response response = resources.client().target("/user/")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .post(Entity.entity(duplicate_fields,MediaType.APPLICATION_JSON_TYPE))
+
+    assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CONFLICT)
+    assertThat(response.hasEntity()).isTrue()
+
+    //If the response entity type isn't of the expected type the Mapper will fail (along with the whole test) and most likely throw an UnrecognizedPropertyException
+    //FIXME There might be a better way to assert the JSON we recieve is the right type
+    ErrorPOJO responseError = MAPPER.readValue(response.getEntity(),ErrorPOJO.class)
+    assertThat(responseError.getErrorCode()).isEqualTo(Response.Status.CONFLICT.getStatusCode())
+    assertThat(responseError.getErrorMessage()).isEqualTo("user_login and display_name fields are not unique.")
+  }
+
+  @Test
+  public void testPost_409_User_login_Unique_Constraint_Violation(){
+    UnableToExecuteStatementException nonUniqueUser_loginException = new UnableToExecuteStatementException("java.sql.SQLIntegrityConstraintViolationException: ORA-00001: unique constraint (MISTSTU1.PR_USER_U_USER_LOGIN) violated")
+
+    when(dao.postUser(anyString(),anyString())).thenThrow(nonUniqueUser_loginException)
+
+    Response response = resources.client().target("/user/")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .post(Entity.entity(user,MediaType.APPLICATION_JSON_TYPE))
+
+    assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CONFLICT)
+    assertThat(response.hasEntity()).isTrue()
+
+    //FIXME There might be a better way to assert the JSON we recieve is the right type
+    ErrorPOJO responseError = MAPPER.readValue(response.getEntity(),ErrorPOJO.class)
+    assertThat(responseError.getErrorCode()).isEqualTo(Response.Status.CONFLICT.getStatusCode())
+    assertThat(responseError.getErrorMessage()).isEqualTo("User login is not unique.")
+
+    //MAPPER.writeValueAsString(MAPPER.readValue(response.getEntity(),ErrorPOJO.class))
+  }
+
+  @Test
+  public void testPost_409_Unique_Constraint_Violation(){
+    UnableToExecuteStatementException nonUniqueDisplay_nameException = new UnableToExecuteStatementException("java.sql.SQLIntegrityConstraintViolationException: ORA-00001: unique constraint (MISTSTU1.PR_USER_U_DISPLAY_NAME) violated")
+
+    when(dao.postUser(anyString(),anyString())).thenThrow(nonUniqueDisplay_nameException)
+
+    Response response = resources.client().target("/user/")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .post(Entity.entity(user,MediaType.APPLICATION_JSON_TYPE))
+
+    assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CONFLICT)
+    assertThat(response.hasEntity()).isTrue()
+
+    //FIXME There might be a better way to assert the JSON we recieve is the right type
+    ErrorPOJO responseError = MAPPER.readValue(response.getEntity(),ErrorPOJO.class)
+    assertThat(responseError.getErrorCode()).isEqualTo(Response.Status.CONFLICT.getStatusCode())
+    assertThat(responseError.getErrorMessage()).isEqualTo("Display name is not unique.")
+  }
+
+
+
 
 }

--- a/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
@@ -99,11 +99,16 @@ class UserResourceTest{
     assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CONFLICT)
     assertThat(response.hasEntity()).isTrue()
 
-    //If the response entity type isn't of the expected type the Mapper will fail (along with the whole test) and most likely throw an UnrecognizedPropertyException
-    //FIXME There might be a better way to assert the JSON we recieve is the right type
-    ErrorPOJO responseError = MAPPER.readValue(response.getEntity(),ErrorPOJO.class)
-    assertThat(responseError.getErrorCode()).isEqualTo(Response.Status.CONFLICT.getStatusCode())
-    assertThat(responseError.getErrorMessage()).isEqualTo("user_login and display_name fields are not unique.")
+    try {
+      ErrorPOJO actual = MAPPER.readValue(response.getEntity() , ErrorPOJO.class)
+      ErrorPOJO expected = new ErrorPOJO(errorMessage:  "user_login and display_name fields are not unique.", errorCode: Response.Status.CONFLICT.getStatusCode())
+
+      assertEquals(expected, actual)
+    }catch (com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException e ){
+      //extends com.fasterxml.jackson.databind.JsonMappingException
+      fail("Mapping to ErrorPOJO failed. Received unexpected Response Entity JSON Schema")
+    }
+
   }
 
   @Test
@@ -119,16 +124,20 @@ class UserResourceTest{
     assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CONFLICT)
     assertThat(response.hasEntity()).isTrue()
 
-    //FIXME There might be a better way to assert the JSON we recieve is the right type
-    ErrorPOJO responseError = MAPPER.readValue(response.getEntity(),ErrorPOJO.class)
-    assertThat(responseError.getErrorCode()).isEqualTo(Response.Status.CONFLICT.getStatusCode())
-    assertThat(responseError.getErrorMessage()).isEqualTo("User login is not unique.")
+    try {
+      ErrorPOJO actual = MAPPER.readValue(response.getEntity() , ErrorPOJO.class)
+      ErrorPOJO expected = new ErrorPOJO(errorMessage: "User login is not unique." , errorCode: Response.Status.CONFLICT.getStatusCode())
+
+      assertEquals(expected, actual)
+    }catch (UnrecognizedPropertyException e){
+      fail("Mapping to ErrorPOJO failed. Received unexpected Response Entity JSON Schema")
+    }
+
 
     //MAPPER.writeValueAsString(MAPPER.readValue(response.getEntity(),ErrorPOJO.class))
   }
-
   @Test
-  public void testPost_409_Unique_Constraint_Violation(){
+  public void testPost_409_Display_name_Unique_Constraint_Violation(){
     UnableToExecuteStatementException nonUniqueDisplay_nameException = new UnableToExecuteStatementException("java.sql.SQLIntegrityConstraintViolationException: ORA-00001: unique constraint (MISTSTU1.PR_USER_U_DISPLAY_NAME) violated")
 
     when(dao.postUser(anyString(),anyString())).thenThrow(nonUniqueDisplay_nameException)
@@ -140,10 +149,15 @@ class UserResourceTest{
     assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CONFLICT)
     assertThat(response.hasEntity()).isTrue()
 
-    //FIXME There might be a better way to assert the JSON we recieve is the right type
-    ErrorPOJO responseError = MAPPER.readValue(response.getEntity(),ErrorPOJO.class)
-    assertThat(responseError.getErrorCode()).isEqualTo(Response.Status.CONFLICT.getStatusCode())
-    assertThat(responseError.getErrorMessage()).isEqualTo("Display name is not unique.")
+    try {
+      ErrorPOJO actual = MAPPER.readValue(response.getEntity() , ErrorPOJO.class)
+      ErrorPOJO expected = new ErrorPOJO(errorMessage: "Display name is not unique.",errorCode: Response.Status.CONFLICT.getStatusCode())
+
+      assertEquals(expected, actual)
+    }catch (UnrecognizedPropertyException e){
+      fail("Mapping to ErrorPOJO failed. Received unexpected Response Entity JSON Schema")
+    }
+
   }
 
 

--- a/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
@@ -72,6 +72,7 @@ class UserResourceTest{
             .request(MediaType.APPLICATION_JSON_TYPE)
             .get()
 
+    verify(dao).allRESTPRUsers()
     assertThat(response.getStatusInfo()).isEqualTo(Response.Status.OK)
     assertThat(response.hasEntity()).isTrue()
   }
@@ -84,6 +85,7 @@ class UserResourceTest{
             .request(MediaType.APPLICATION_JSON_TYPE)
             .get()
 
+    verify(dao).getPRUSERSmatch(anyString(),anyString())
     assertThat(response.getStatusInfo()).isEqualTo(Response.Status.OK)
     assertThat(response.hasEntity()).isTrue()
   }
@@ -121,6 +123,8 @@ class UserResourceTest{
             .request(MediaType.APPLICATION_JSON_TYPE)
             .post(Entity.entity(user,MediaType.APPLICATION_JSON_TYPE))
 
+    verify(dao).postUser(anyString(),anyString())
+
     assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CONFLICT)
     assertThat(response.hasEntity()).isTrue()
 
@@ -146,6 +150,8 @@ class UserResourceTest{
             .request(MediaType.APPLICATION_JSON_TYPE)
             .post(Entity.entity(user,MediaType.APPLICATION_JSON_TYPE))
 
+    verify(dao).postUser(anyString(),anyString())
+
     assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CONFLICT)
     assertThat(response.hasEntity()).isTrue()
 
@@ -159,7 +165,6 @@ class UserResourceTest{
     }
 
   }
-
   @Test
   public void testPost_201(){
     when(dao.getLatestUserId()).thenReturn(1)
@@ -168,6 +173,7 @@ class UserResourceTest{
             .request(MediaType.APPLICATION_JSON_TYPE)
             .post(Entity.entity(user,MediaType.APPLICATION_JSON_TYPE))
 
+    verify(dao).getLatestUserId()
     assertThat(response.getStatusInfo()).isEqualTo(Response.Status.CREATED)
     System.out.println(response.getHeaders())
     System.out.println(response.getHeaderString("Location"))

--- a/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/restpr/resources/UserResourceTest.groovy
@@ -3,30 +3,32 @@ package edu.oregonstate.mist.restpr.resources
 import edu.oregonstate.mist.restpr.api.ErrorPOJO
 import edu.oregonstate.mist.restpr.api.User
 import edu.oregonstate.mist.restpr.db.UserDAO
-import edu.oregonstate.mist.restpr.resources.UserResource
 import io.dropwizard.jackson.Jackson
-import io.dropwizard.testing.ResourceHelpers
 import io.dropwizard.testing.junit.ResourceTestRule
-
-import org.junit.After
-import io.dropwizard.testing.junit.DropwizardAppRule
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.junit.AfterClass
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.ClassRule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.runners.MockitoJUnitRunner
 import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException
-
 import javax.ws.rs.client.Entity
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
-import static io.dropwizard.testing.FixtureHelpers.fixture
 import static org.assertj.core.api.Assertions.assertThat
+import static org.assertj.core.api.Assertions.fail
+import static org.junit.Assert.assertEquals
+import static org.mockito.Matchers.anyString
 import static org.mockito.Mockito.*
+
+/*
+  Using mock testing provided by mockito we can isolate the behavior of the DAO.
+  This means we won't have to rely on test data from a db connection or anything like that.
+  By mocking the dao class we can feed the mock the behavior (db responses) we want.
+  Using this isolation we can unit test the resource code and assert we get the expected responses.
+*/
 
 class UserResourceTest{
   static UserDAO dao = mock(UserDAO.class)
@@ -64,13 +66,6 @@ class UserResourceTest{
   public void testGetAll_200() {
     //TODO make database model
 
-    //Using mocking we isolate the behavior of the database by mocking the dao class
-    //We can feed the mock the behavior (db responses) we want.
-    //Using this isolation we can unit test the resource code and the responses we get back
-
-    //DAO behavior we need to mock
-    //List<User> allRESTPRUsers()
-    //Mock the DAO to test the resource's usage of the mocked DAO
     when(dao.allRESTPRUsers()).thenReturn(returnMockList)
 
     Response response = resources.client().target("/user/all")

--- a/src/test/resources/fixtures/errorpojo.json
+++ b/src/test/resources/fixtures/errorpojo.json
@@ -1,0 +1,4 @@
+{
+    "errorMessage": "Resource not found",
+    "errorCode": 404
+}

--- a/src/test/resources/fixtures/season.json
+++ b/src/test/resources/fixtures/season.json
@@ -1,0 +1,8 @@
+{
+  "season_id":22,
+  "community_name": "Test POST",
+  "cycle_format":  "Feb",
+  "cycle_count": "Monthly",
+  "elo_default_seed": 1200,
+  "year": 2015
+}

--- a/src/test/resources/fixtures/user.json
+++ b/src/test/resources/fixtures/user.json
@@ -1,0 +1,4 @@
+{
+  "display_name": "DISPLAY_NAME_TEST",
+  "user_login": "USER_LOGIN_TEST"
+}

--- a/src/test/resources/fixtures/user.json
+++ b/src/test/resources/fixtures/user.json
@@ -1,4 +1,5 @@
 {
+  "user_id": 1,
   "display_name": "DISPLAY_NAME_TEST",
   "user_login": "USER_LOGIN_TEST"
 }


### PR DESCRIPTION
Overview of this PR:
Add fixtures for the classes that get serialized to and from JSON (ErrorPOJO, Season, User)
Remove explicit constructor for ErrorPOJO class and use Groovy map constructor instead.
Add serialization and deserialization unit tests for ErrorPOJO, Season and User classes.
Add equals method to ErrorPOJO, Season and User classes to bugfix assertEquals behavior when     applied to those classes.
Add condition to postUser method in UserResource.groovy that checks for duplicate user_login and     display_name fields within the input User parameter.

Unit tests added for UserResource.groovy:

testDeleteUser_200
testGetAll_200
testGetMatch_200
testGetUserById_200
testGetUserById_404
testPost_201
testPost_409_Display_name_Unique_Constraint_Violation
testPost_409_Duplicate_Fields
testPost_409_User_login_Unique_Constraint_Violation 
testPutUserById_200
testPutUserById_CheckForUser_id_null
